### PR TITLE
Fix build error on ts6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      - name: Build
+        run: npm ci && npm run build

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "types": ["dom-chromium-ai"],
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
TypeScript 6.0 から `types` がデフォルトで `[]` になったため、`["dom-chromium-ai"]` と明に指定する。
https://github.com/microsoft/TypeScript/issues/62195

合わせて、マージ前にビルドエラーに気付くように、PR作成時にビルドする GitHub Actionsを追加する。